### PR TITLE
Fix: Declaration file is generated with incorrect syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 
 With script tag in the browser:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/parse-mediawiki-template@0.2.0/dist/parse-mediawiki-template.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/parse-mediawiki-template@0.2.1/dist/parse-mediawiki-template.umd.js"></script>
 ```
 
 ## USAGE

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ The function will parse wikitext (parameter 1) and find all occurences of the sp
 The result is an array with an entry for each occurence. If the template has parameters, it will list them.
 
 ```js
-const parseMediawikiTemplate = require('parse-mediawiki-template')
+import parseMediawikiTemplate from 'parse-mediawiki-template';
 
-const wikitext = 'Page content {{Template|param1|foo=paramFoo}} {{OtherTemplate}} {{Template|second|occurence}}'
-const template = 'template'
+const wikitext = 'Page content {{Template|param1|foo=paramFoo}} {{OtherTemplate}} {{Template|second|occurence}}';
+const template = 'template';
 
-const result = parseMediawikiTemplate(wikitext, template)
+const result = parseMediawikiTemplate(wikitext, template);
 ```
 
 result is:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parse-mediawiki-template",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parse-mediawiki-template",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.12.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.12.2",
+        "@types/node": "^20.12.11",
         "prettier": "^3.2.5",
-        "typescript": "^5.4.3",
-        "vite": "^5.2.7",
-        "vite-plugin-dts": "^3.8.1",
-        "vitest": "^1.4.0"
+        "typescript": "^5.4.5",
+        "vite": "^5.2.11",
+        "vite-plugin-dts": "^3.9.1",
+        "vitest": "^1.6.0"
       }
     },
     "node_modules/@babel/parser": {
@@ -853,22 +853,22 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.2.tgz",
-      "integrity": "sha512-zQ0NYO87hyN6Xrclcqp7f8ZbXNbRfoGWNcMvHTPQp9UUrwI0mI7XBz+cu7/W6/VClYo2g63B0cjull/srU7LgQ==",
+      "version": "20.12.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
+      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.4.0.tgz",
-      "integrity": "sha512-Jths0sWCJZ8BxjKe+p+eKsoqev1/T8lYcrjavEaz8auEJ4jAVY0GwW3JKmdVU4mmNPLPHixh4GNXP7GFtAiDHA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
+      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
       "dev": true,
       "dependencies": {
-        "@vitest/spy": "1.4.0",
-        "@vitest/utils": "1.4.0",
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
         "chai": "^4.3.10"
       },
       "funding": {
@@ -876,12 +876,12 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.4.0.tgz",
-      "integrity": "sha512-EDYVSmesqlQ4RD2VvWo3hQgTJ7ZrFQ2VSJdfiJiArkCerDAGeyF1i6dHkmySqk573jLp6d/cfqCN+7wUB5tLgg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
+      "integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
       "dev": true,
       "dependencies": {
-        "@vitest/utils": "1.4.0",
+        "@vitest/utils": "1.6.0",
         "p-limit": "^5.0.0",
         "pathe": "^1.1.1"
       },
@@ -890,9 +890,9 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.4.0.tgz",
-      "integrity": "sha512-saAFnt5pPIA5qDGxOHxJ/XxhMFKkUSBJmVt5VgDsAqPTX6JP326r5C/c9UuCMPoXNzuudTPsYDZCoJ5ilpqG2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
+      "integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
       "dev": true,
       "dependencies": {
         "magic-string": "^0.30.5",
@@ -904,9 +904,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.4.0.tgz",
-      "integrity": "sha512-Ywau/Qs1DzM/8Uc+yA77CwSegizMlcgTJuYGAi0jujOteJOUf1ujunHThYo243KG9nAyWT3L9ifPYZ5+As/+6Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
+      "integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
       "dev": true,
       "dependencies": {
         "tinyspy": "^2.2.0"
@@ -916,9 +916,9 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.4.0.tgz",
-      "integrity": "sha512-mx3Yd1/6e2Vt/PUC98DcqTirtfxUyAZ32uK82r8rZzbtBeBo+nqgnjx/LvqQdWsrvNtm14VmurNgcf4nqY5gJg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
       "dev": true,
       "dependencies": {
         "diff-sequences": "^29.6.3",
@@ -1816,9 +1816,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
     "node_modules/resolve": {
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
-      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2105,9 +2105,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.7.tgz",
-      "integrity": "sha512-k14PWOKLI6pMaSzAuGtT+Cf0YmIx12z9YGon39onaJNy8DLBfBJrzg9FQEmkAM5lpHBZs9wksWAsyF/HkpEwJA==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
+      "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.20.1",
@@ -2160,9 +2160,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.4.0.tgz",
-      "integrity": "sha512-VZDAseqjrHgNd4Kh8icYHWzTKSCZMhia7GyHfhtzLW33fZlG9SwsB6CEhgyVOWkJfJ2pFLrp/Gj1FSfAiqH9Lw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
+      "integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
       "dev": true,
       "dependencies": {
         "cac": "^6.7.14",
@@ -2182,9 +2182,9 @@
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.8.1.tgz",
-      "integrity": "sha512-zEYyQxH7lKto1VTKZHF3ZZeOPkkJgnMrePY4VxDHfDSvDjmYMMfWjZxYmNwW8QxbaItWJQhhXY+geAbyNphI7g==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-3.9.1.tgz",
+      "integrity": "sha512-rVp2KM9Ue22NGWB8dNtWEr+KekN3rIgz1tWD050QnRGlriUCmaDwa7qA5zDEjbXg5lAXhYMSBJtx3q3hQIJZSg==",
       "dev": true,
       "dependencies": {
         "@microsoft/api-extractor": "7.43.0",
@@ -2209,16 +2209,16 @@
       }
     },
     "node_modules/vitest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.4.0.tgz",
-      "integrity": "sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
+      "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
       "dev": true,
       "dependencies": {
-        "@vitest/expect": "1.4.0",
-        "@vitest/runner": "1.4.0",
-        "@vitest/snapshot": "1.4.0",
-        "@vitest/spy": "1.4.0",
-        "@vitest/utils": "1.4.0",
+        "@vitest/expect": "1.6.0",
+        "@vitest/runner": "1.6.0",
+        "@vitest/snapshot": "1.6.0",
+        "@vitest/spy": "1.6.0",
+        "@vitest/utils": "1.6.0",
         "acorn-walk": "^8.3.2",
         "chai": "^4.3.10",
         "debug": "^4.3.4",
@@ -2230,9 +2230,9 @@
         "std-env": "^3.5.0",
         "strip-literal": "^2.0.0",
         "tinybench": "^2.5.1",
-        "tinypool": "^0.8.2",
+        "tinypool": "^0.8.3",
         "vite": "^5.0.0",
-        "vite-node": "1.4.0",
+        "vite-node": "1.6.0",
         "why-is-node-running": "^2.2.2"
       },
       "bin": {
@@ -2247,8 +2247,8 @@
       "peerDependencies": {
         "@edge-runtime/vm": "*",
         "@types/node": "^18.0.0 || >=20.0.0",
-        "@vitest/browser": "1.4.0",
-        "@vitest/ui": "1.4.0",
+        "@vitest/browser": "1.6.0",
+        "@vitest/ui": "1.6.0",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   },
   "homepage": "https://github.com/plepe/parse-mediawiki-template#readme",
   "devDependencies": {
-    "@types/node": "^20.12.2",
+    "@types/node": "^20.12.11",
     "prettier": "^3.2.5",
-    "typescript": "^5.4.3",
-    "vite": "^5.2.7",
-    "vite-plugin-dts": "^3.8.1",
-    "vitest": "^1.4.0"
+    "typescript": "^5.4.5",
+    "vite": "^5.2.11",
+    "vite-plugin-dts": "^3.9.1",
+    "vitest": "^1.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-mediawiki-template",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Parses all occurences of a Mediawiki Template from Mediawiki text",
   "type": "module",
   "main": "./dist/parse-mediawiki-template.js",

--- a/src/parse-mediawiki-template.ts
+++ b/src/parse-mediawiki-template.ts
@@ -33,7 +33,7 @@ function findNested(str: string) {
   return length;
 }
 
-export default function parseMWTemplate(str: string, templateId: string) {
+function parseMWTemplate(str: string, templateId: string) {
   const results = [];
 
   const regexStart = new RegExp('(\\{\\{\\s*' + templateId + '\\s*(\\||\\}\\}))', 'im');
@@ -95,3 +95,5 @@ export default function parseMWTemplate(str: string, templateId: string) {
 
   return results;
 }
+
+export default parseMWTemplate;

--- a/test/parse-mediawiki-template.test.ts
+++ b/test/parse-mediawiki-template.test.ts
@@ -1,4 +1,4 @@
-import parseMWTemplate from '@/parse-mediawiki-template.js';
+import parseMWTemplate from '@/parse-mediawiki-template';
 import { describe, expect, it } from 'vitest';
 
 describe('parseMWTemplate', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   base: './',
   plugins: [
     dts({
-      exclude: ['**/**.spec.**', '*.config.*'],
+      exclude: ['**/**.test.**', '*.config.*'],
       insertTypesEntry: true,
     }),
   ],


### PR DESCRIPTION
The `export default function parseMWTemplate() {}` apparently broke something and Vite didn't properly generate the declaration for the function, effectively breaking the library.
Putting the `export default parseMWTemplate` on its own line fixes this.

I also changed the README to use ESM import syntax instead of CJS, and excluded the test file from the built bundle.

Sorry for the trouble, and thanks again for merging!