### PR TITLE
add release action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish
+run-name: Publish
+
+on: workflow_dispatch
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Get version
+        run: |
+          version=$(npm pkg get version | xargs)
+          echo "TAG=${version}" >> $GITHUB_ENV
+
+      - name: Push tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ env.TAG }}
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: create-tag
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Build Package
+        run: |
+          npm ci
+          npm run build
+          cd dist
+          mv parse-mediawiki-template.umd.cjs parse-mediawiki-template-min.js
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 
 With script tag in the browser:
 ```html
-<script src="https://cdn.jsdelivr.net/npm/parse-mediawiki-template@0.2.2/dist/parse-mediawiki-template.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/parse-mediawiki-template@0.2.2/dist/parse-mediawiki-template-min.js"></script>
 ```
 
 ## USAGE


### PR DESCRIPTION
To automate the release process and remove potential for human error, I made a GH action workflow for publishing the package to NPM that can be triggered manually.
It takes the `version` from `package.json` and creates a matching tag on GitHub. That means that the version in package.json must still be bumped by a human, the workflow just handles the publishing.
It then builds and publishes the files to NPM.

For authentication with NPM, it requires an access token that can be generated from the NPM settings.
That token should be added as a repository secret in the repo settings with the name `NPM_TOKEN`.

Feel free to reject the PR if you prefer to do the release process manually :)